### PR TITLE
Update callbacks after insert

### DIFF
--- a/lib/callbacks.ex
+++ b/lib/callbacks.ex
@@ -79,7 +79,7 @@ defmodule Autocontext.EctoCallbacks do
         case @repo.insert(changeset) do
           {:ok, record} ->
             run_callbacks(:after_save, record)
-            run_callbacks(:before_create, changeset)
+            run_callbacks(:after_create, changeset)
             {:ok, record}
 
           error ->


### PR DESCRIPTION
Was browsing through the code and saw a line I think should be updated.  Updates callback after insert to `:after_create`.